### PR TITLE
remove auth on server side (unnecessary)

### DIFF
--- a/pages/home.js
+++ b/pages/home.js
@@ -2,18 +2,8 @@ import { useState } from "react";
 import Head from "next/head";
 import Button from "../components/button";
 import DashNavbar from "../components/dashNavbar";
-import { isAuthenticated, redirectHome } from "../lib/serverSideAuth";
 import HeirloomSettingsModal from "../components/heirloomSettingsModal";
 import SelectedRectangle from "../components/selectedRectangle";
-
-// comment this out for dev if necessary
-export async function getServerSideProps(ctx) {
-  const isAuth = await isAuthenticated(ctx);
-  if (!isAuth) return redirectHome(ctx);
-  return {
-    props: {},
-  };
-}
 
 export default function Home() {
   const [tab, setTab] = useState(0);


### PR DESCRIPTION
Deleting this for the time being. We don't need server side auth after all since we can authenticate on the client. This avoids unnecessary re-rendering